### PR TITLE
Do not fail when the config cannot be loaded

### DIFF
--- a/protobix/datacontainer.py
+++ b/protobix/datacontainer.py
@@ -148,7 +148,10 @@ class DataContainer(SenderProtocol):
         #               3 -> logging.WARNING
         #               4 -> logging.DEBUG
         # - Timeout (default: 3, Allowed: 1-30)
-        tmp_config = configobj.ConfigObj(config_file)
+        try:
+            tmp_config = configobj.ConfigObj(config_file)
+        except:
+            return False
 
         if 'ServerActive' in tmp_config:
             tmp_server = tmp_config['ServerActive'][0] \


### PR DESCRIPTION
The current implementation fails whenever it finds a config entry in the Agent configuration it doesn't like such as:
```
UserParameter=net.ping[*],/usr/bin/fping -q -c3 $1 2>&1 | sed 's,.*/\([0-9.]*\)/.*,\1,'
```

This should prevent that from happening.