### PR TITLE
Fix configuration read from zabbix_agentd

### DIFF
--- a/protobix/datacontainer.py
+++ b/protobix/datacontainer.py
@@ -150,14 +150,19 @@ class DataContainer(SenderProtocol):
         #               3 -> logging.WARNING
         #               4 -> logging.DEBUG
         # - Timeout (default: 3, Allowed: 1-30)
+
+        # list_values=False argument bellow is needed because of UserParameter with spaces
         tmp_config = configobj.ConfigObj(config_file, list_values=False)
 
         if 'ServerActive' in tmp_config:
-            tmp_server = tmp_config['ServerActive'][0] \
-                         if isinstance(tmp_config['ServerActive'], list) \
-                         else list(tmp_config['ServerActive'])[0]
+            # Because of list_values=False above,
+            # we have to check ServerActive and make the split manually
+            tmp_server = tmp_config['ServerActive'].split(',')[0] \
+                         if "," in tmp_config['ServerActive'] \
+                         else tmp_config['ServerActive']
             self._config['server'], self._config['port'] = tmp_server.split(':') \
                          if ":" in tmp_server else (tmp_server, 10051)
+            self._config['port'] = int(self._config['port'])
 
         if 'LogFile' in tmp_config:
             self._config['log_output'] = tmp_config['LogFile']

--- a/tests/test_04ReadZabbixFile.py
+++ b/tests/test_04ReadZabbixFile.py
@@ -1,0 +1,100 @@
+import pytest, coverage
+import unittest
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+import protobix
+import logging
+
+class TestZabbixFile(object):
+
+#   @classmethod
+#   def setup_class(cls):
+#       common_log_format = '[%(name)s:%(levelname)s] %(message)s'
+#       cls.logger = logging.getLogger(cls.__class__.__name__)
+#       consoleHandler = logging.StreamHandler()
+#       consoleFormatter = logging.Formatter(
+#           fmt = common_log_format,
+#           datefmt = '%Y%m%d:%H%M%S'
+#       )
+#       consoleHandler.setFormatter(consoleFormatter)
+#       cls.logger.addHandler(consoleHandler)
+
+#       cls.zbx_container = protobix.DataContainer(logger=cls.logger)
+#       cls.zbx_container._items_list = []
+#       cls.zbx_container._config = {
+#           'server': '127.0.0.1',
+#           'port': 10051,
+#           'log_level': 3,
+#           'log_output': '/tmp/zabbix_agentd.log',
+#           'dryrun': False,
+#           'data_type': None,
+#           'timeout': 3
+#       }
+
+#   @classmethod
+#   def teardown_class(cls):
+#       cls.zbx_container._items_list = []
+#       cls.zbx_container._config = {
+#           'server': '127.0.0.1',
+#           'port': 10051,
+#           'log_level': 3,
+#           'log_output': '/tmp/zabbix_agentd.log',
+#           'dryrun': False,
+#           'data_type': None,
+#           'timeout': 3
+#       }
+#       cls.zbx_container = None
+#       cls.logger = None
+
+#   def setup_method(self, method):
+#       self.zbx_container._items_list = []
+#       self.zbx_container._config = {
+#           'server': '127.0.0.1',
+#           'port': 10051,
+#           'log_level': 3,
+#           'log_output': '/tmp/zabbix_agentd.log',
+#           'dryrun': False,
+#           'data_type': None,
+#           'timeout': 3
+#       }
+
+#   def teardown_method(self, method):
+#       self.zbx_container._items_list = []
+#       self.zbx_container._config = {
+#           'server': '127.0.0.1',
+#           'port': 10051,
+#           'log_level': 3,
+#           'log_output': '/tmp/zabbix_agentd.log',
+#           'dryrun': False,
+#           'data_type': None,
+#           'timeout': 3
+#       }
+
+    def test_default_params(self):
+        self.zbx_container = protobix.DataContainer(
+                        data_type  = 'items',
+        )
+        assert self.zbx_container._config == {
+            'server': '127.0.0.1',
+            'port': 10051,
+            'log_level': 3,
+            'log_output': '/tmp/zabbix_agentd.log',
+            'dryrun': False,
+            'data_type': 'items',
+            'timeout': 3
+        }
+
+    def test_custom_params(self):
+        self.zbx_container = protobix.DataContainer(
+                        data_type  = 'items',
+                        zbx_file   = './tests/zabbix_agentd.conf',
+        )
+        assert self.zbx_container._config == {
+            'server': '127.0.1.1',
+            'port': 10061,
+            'log_level': 3,
+            'log_output': '/tmp/test_zabbix_agentd.log',
+            'dryrun': False,
+            'data_type': 'items',
+            'timeout': 3
+        }

--- a/tests/zabbix_agentd.conf
+++ b/tests/zabbix_agentd.conf
@@ -18,7 +18,7 @@
 # Default:
 # LogFile=
 
-LogFile=/tmp/zabbix_agentd.log
+LogFile=/tmp/test_zabbix_agentd.log
 
 ### Option: LogFileSize
 #	Maximum size of log file in MB.
@@ -80,7 +80,7 @@ DebugLevel=3
 # Default:
 # Server=
 
-Server=127.0.0.1
+Server=127.0.1.1
 
 ### Option: ListenPort
 #	Agent will listen on this port for connections from the server.
@@ -88,7 +88,7 @@ Server=127.0.0.1
 # Mandatory: no
 # Range: 1024-32767
 # Default:
-# ListenPort=10050
+ListenPort=10060
 
 ### Option: ListenIP
 #	List of comma delimited IP addresses that the agent should listen on.
@@ -121,7 +121,7 @@ Server=127.0.0.1
 # Default:
 # ServerActive=
 
-ServerActive=127.0.0.1:10051,10.0.0.1:10051
+ServerActive=127.0.1.1:10061,10.0.0.1:10051
 
 ### Option: Hostname
 #	Unique, case sensitive hostname.


### PR DESCRIPTION
`ServerActive` wasn't parsed correctly leading to use a wrong server.