### PR TITLE
Configuration options changes

### DIFF
--- a/protobix/datacontainer.py
+++ b/protobix/datacontainer.py
@@ -25,7 +25,7 @@ class DataContainer(SenderProtocol):
                  zbx_file='/etc/zabbix/zabbix_agentd.conf',
                  zbx_host=None,
                  zbx_port=None,
-                 log_level=None,
+                 debug_level=None,
                  log_output=None,
                  dryrun=False,
                  logger=None):
@@ -40,8 +40,8 @@ class DataContainer(SenderProtocol):
             'data_type': None
         }
         # Override default values with the ones provided
-        if log_level:
-            self.log_level = log_level
+        if debug_level:
+            self.debug_level = debug_level
         if log_output != None:
             self._zbx_config.log_file = log_output
         if zbx_host:
@@ -125,7 +125,7 @@ class DataContainer(SenderProtocol):
     def send(self):
         results_list = []
         try:
-            if self.log_level >= 4:
+            if self.debug_level >= 4:
                 # If debug mode enabled Sent one item at a time
                 for item in self._items_list:
                     result = self._send_common(item)
@@ -154,7 +154,7 @@ class DataContainer(SenderProtocol):
         if self.logger:
             output_key = '(bulk)'
             output_item = '(bulk)'
-            if self.log_level >= 4:
+            if self.debug_level >= 4:
                 output_key = item['key']
                 output_item = item['value']
             self.logger.info(

--- a/protobix/senderprotocol.py
+++ b/protobix/senderprotocol.py
@@ -66,11 +66,11 @@ class SenderProtocol(object):
             raise ValueError('dryrun parameter requires boolean')
 
     @property
-    def log_level(self):
+    def debug_level(self):
         return self._zbx_config.debug_level
 
-    @log_level.setter
-    def log_level(self, value):
+    @debug_level.setter
+    def debug_level(self, value):
         self._zbx_config.debug_level = value
 
     @property

--- a/protobix/zabbixagentconfig.py
+++ b/protobix/zabbixagentconfig.py
@@ -24,6 +24,8 @@ class ZabbixAgentConfig(object):
             'TLSKeyFile': None,
             'TLSServerCertIssuer': None,
             'TLSServerCertSubject': None,
+            'TLSPSKIdentity': None,
+            'TLSPSKFile': None,
         }
 
         # list_values=False argument below is needed because of potential
@@ -87,12 +89,12 @@ class ZabbixAgentConfig(object):
         if 'TLSConnect' in tmp_config:
             self.tls_connect = tmp_config['TLSConnect']
 
-        if self.tls_connect and self.tls_connect != 'unencrypted':
+        if self.tls_connect == 'cert':
             if 'TLSCertFile' in tmp_config and 'TLSKeyFile' in tmp_config:
                     self.tls_cert_file = tmp_config['TLSCertFile']
                     self.tls_key_file = tmp_config['TLSKeyFile']
             else:
-                raise ValueError('TLSConnect is enabled. TLSCertFile and TLSKeyFile are mandatory')
+                raise ValueError('TLSConnect is cert. TLSCertFile and TLSKeyFile are mandatory')
             if 'TLSCAFile' in tmp_config:
                 self.tls_ca_file = tmp_config['TLSCAFile']
             if 'TLSCRLFile' in tmp_config:
@@ -101,6 +103,13 @@ class ZabbixAgentConfig(object):
                 self.tls_server_cert_issuer = tmp_config['TLSServerCertIssuer']
             if 'TLSServerCertSubject' in tmp_config:
                 self.tls_server_cert_subject = tmp_config['TLSServerCertSubject']
+
+        if self.tls_connect == 'psk':
+            if 'TLSPSKIdentity' in tmp_config and 'TLSPSKFile' in tmp_config:
+                self.tls_psk_identity = tmp_config['TLSPSKIdentity']
+                self.tls_psk_file = tmp_config['TLSPSKFile']
+            else:
+                raise ValueError('TLSConnect is psk. TLSPSKIdentity and TLSPSKFile are mandatory')
 
     @property
     def server_active(self):
@@ -184,12 +193,10 @@ class ZabbixAgentConfig(object):
 
     @tls_connect.setter
     def tls_connect(self, value):
-        if value in ['unencrypted', 'cert']:
+        if value in ['unencrypted', 'psk', 'cert']:
             self.config['TLSConnect'] = value
-        elif value == 'psk':
-            raise NotImplementedError('TLSConnect must be one of [unencrypted,cert] (psk is not implemented)')
         else:
-            raise ValueError('TLSConnect must be one of [unencrypted,cert] (psk is not implemented)')
+            raise ValueError('TLSConnect must be one of [unencrypted,psk,cert]')
 
     @property
     def tls_ca_file(self):
@@ -244,3 +251,21 @@ class ZabbixAgentConfig(object):
     def tls_server_cert_subject(self, value):
         if value:
             self.config['TLSServerCertSubject'] = value
+
+    @property
+    def tls_psk_identity(self):
+        return self.config['TLSPSKIdentity']
+
+    @tls_psk_identity.setter
+    def tls_psk_identity(self, value):
+        if value:
+            self.config['TLSPSKIdentity'] = value
+
+    @property
+    def tls_psk_file(self):
+        return self.config['TLSPSKFile']
+
+    @tls_psk_file.setter
+    def tls_psk_file(self, value):
+        if value:
+            self.config['TLSPSKFile'] = value

--- a/tests/test_datacontainer_item.py
+++ b/tests/test_datacontainer_item.py
@@ -58,7 +58,7 @@ def test_debug_no_dryrun_no(mock_configobj, mock_zabbix_agent_config):
     assert len(zbx_datacontainer.items_list) == 4
 
     assert zbx_datacontainer.dryrun is False
-    assert zbx_datacontainer.log_level < 4
+    assert zbx_datacontainer.debug_level < 4
 
     ''' Send data to zabbix '''
     # Allow static tests to pass
@@ -83,14 +83,14 @@ def test_debug_yes_dryrun_no(mock_configobj, mock_zabbix_agent_config):
     mock_configobj.side_effect = [{}]
     mock_zabbix_agent_config.return_value = protobix.ZabbixAgentConfig()
     zbx_datacontainer = protobix.DataContainer()
-    zbx_datacontainer.log_level = 4
+    zbx_datacontainer.debug_level = 4
     zbx_datacontainer.data_type = DATA_TYPE
     assert zbx_datacontainer.items_list == []
     zbx_datacontainer.add(DATA)
     assert len(zbx_datacontainer.items_list) == 4
 
     assert zbx_datacontainer.dryrun is False
-    assert zbx_datacontainer.log_level >= 4
+    assert zbx_datacontainer.debug_level >= 4
 
     ''' Send data to zabbix '''
     # Allow static tests to pass
@@ -121,7 +121,7 @@ def test_debug_no_dryrun_yes(mock_configobj, mock_zabbix_agent_config):
     assert len(zbx_datacontainer.items_list) == 4
 
     assert zbx_datacontainer.dryrun is True
-    assert zbx_datacontainer.log_level < 4
+    assert zbx_datacontainer.debug_level < 4
 
     ''' Send data to zabbix '''
     results_list = zbx_datacontainer.send()
@@ -140,13 +140,13 @@ def test_debug_yes_dryrun_yes(mock_configobj, mock_zabbix_agent_config):
     zbx_datacontainer = protobix.DataContainer()
     zbx_datacontainer.data_type = DATA_TYPE
     zbx_datacontainer.dryrun = True
-    zbx_datacontainer.log_level = 4
+    zbx_datacontainer.debug_level = 4
     assert zbx_datacontainer.items_list == []
     zbx_datacontainer.add(DATA)
     assert len(zbx_datacontainer.items_list) == 4
 
     assert zbx_datacontainer.dryrun is True
-    assert zbx_datacontainer.log_level >= 4
+    assert zbx_datacontainer.debug_level >= 4
 
     ''' Send data to zabbix '''
     results_list = zbx_datacontainer.send()

--- a/tests/test_datacontainer_lld.py
+++ b/tests/test_datacontainer_lld.py
@@ -78,7 +78,7 @@ def test_debug_no_dryrun_no(mock_configobj, mock_zabbix_agent_config):
     assert len(zbx_datacontainer.items_list) == 4
 
     assert zbx_datacontainer.dryrun is False
-    assert zbx_datacontainer.log_level < 4
+    assert zbx_datacontainer.debug_level < 4
 
     ''' Send data to zabbix '''
     # Allow static tests to pass
@@ -103,14 +103,14 @@ def test_debug_yes_dryrun_no(mock_configobj, mock_zabbix_agent_config):
     mock_configobj.side_effect = [{}]
     mock_zabbix_agent_config.return_value = protobix.ZabbixAgentConfig()
     zbx_datacontainer = protobix.DataContainer()
-    zbx_datacontainer.log_level = 4
+    zbx_datacontainer.debug_level = 4
     zbx_datacontainer.data_type = DATA_TYPE
     assert zbx_datacontainer.items_list == []
     zbx_datacontainer.add(DATA)
     assert len(zbx_datacontainer.items_list) == 4
 
     assert zbx_datacontainer.dryrun is False
-    assert zbx_datacontainer.log_level >= 4
+    assert zbx_datacontainer.debug_level >= 4
 
     ''' Send data to zabbix '''
     # Allow static tests to pass
@@ -141,7 +141,7 @@ def test_debug_no_dryrun_yes(mock_configobj, mock_zabbix_agent_config):
     assert len(zbx_datacontainer.items_list) == 4
 
     assert zbx_datacontainer.dryrun is True
-    assert zbx_datacontainer.log_level < 4
+    assert zbx_datacontainer.debug_level < 4
 
     ''' Send data to zabbix '''
     results_list = zbx_datacontainer.send()
@@ -160,13 +160,13 @@ def test_debug_yes_dryrun_yes(mock_configobj, mock_zabbix_agent_config):
     zbx_datacontainer = protobix.DataContainer()
     zbx_datacontainer.data_type = DATA_TYPE
     zbx_datacontainer.dryrun = True
-    zbx_datacontainer.log_level = 4
+    zbx_datacontainer.debug_level = 4
     assert zbx_datacontainer.items_list == []
     zbx_datacontainer.add(DATA)
     assert len(zbx_datacontainer.items_list) == 4
 
     assert zbx_datacontainer.dryrun is True
-    assert zbx_datacontainer.log_level >= 4
+    assert zbx_datacontainer.debug_level >= 4
 
     ''' Send data to zabbix '''
     results_list = zbx_datacontainer.send()

--- a/tests/test_memory_leak.py
+++ b/tests/test_memory_leak.py
@@ -81,13 +81,13 @@ PAYLOAD = {
     }
 }
 
-def long_run(data_type, log_level):
+def long_run(data_type, debug_level):
     """
     Generic long running process simulator
     Used by tests below
     """
     zbx_container = protobix.DataContainer(
-        log_level = log_level,
+        debug_level = debug_level,
     )
     run=1
     max_run=1000

--- a/tests/test_senderprotocol.py
+++ b/tests/test_senderprotocol.py
@@ -103,9 +103,9 @@ def test_debug_custom(mock_configobj):
     """
     mock_configobj.side_effect = [{}]
     zbx_senderprotocol = protobix.SenderProtocol()
-    assert zbx_senderprotocol.log_level == 3
-    zbx_senderprotocol.log_level = 4
-    assert zbx_senderprotocol.log_level == 4
+    assert zbx_senderprotocol.debug_level == 3
+    zbx_senderprotocol.debug_level = 4
+    assert zbx_senderprotocol.debug_level == 4
 
 @mock.patch('configobj.ConfigObj')
 def test_debug_invalid_lower_than_0(mock_configobj):
@@ -115,9 +115,9 @@ def test_debug_invalid_lower_than_0(mock_configobj):
     mock_configobj.side_effect = [{}]
     zbx_senderprotocol = protobix.SenderProtocol()
     with pytest.raises(ValueError) as err:
-        zbx_senderprotocol.log_level = -1
+        zbx_senderprotocol.debug_level = -1
     assert str(err.value) == 'DebugLevel must be between 0 and 5'
-    assert zbx_senderprotocol.log_level == 3
+    assert zbx_senderprotocol.debug_level == 3
 
 @mock.patch('configobj.ConfigObj')
 def test_debug_invalid_greater_than_5(mock_configobj):
@@ -127,9 +127,9 @@ def test_debug_invalid_greater_than_5(mock_configobj):
     mock_configobj.side_effect = [{}]
     zbx_senderprotocol = protobix.SenderProtocol()
     with pytest.raises(ValueError) as err:
-        zbx_senderprotocol.log_level = 10
+        zbx_senderprotocol.debug_level = 10
     assert str(err.value) == 'DebugLevel must be between 0 and 5'
-    assert zbx_senderprotocol.log_level == 3
+    assert zbx_senderprotocol.debug_level == 3
 
 @mock.patch('configobj.ConfigObj')
 def test_dryrun_custom(mock_configobj):

--- a/tests/test_zabbixagentconfig.py
+++ b/tests/test_zabbixagentconfig.py
@@ -412,7 +412,7 @@ def test_tls_connect_cert_tls_cert_key_missing(mock_configobj):
     ]
     with pytest.raises(ValueError) as err:
         protobix.ZabbixAgentConfig('TLSConnect_cert_without_TLSCertFile_TLSKeyFile')
-    assert str(err.value) == 'TLSConnect is enabled. TLSCertFile and TLSKeyFile are mandatory'
+    assert str(err.value) == 'TLSConnect is cert. TLSCertFile and TLSKeyFile are mandatory'
 
 @mock.patch('configobj.ConfigObj')
 def test_tls_connect_cert_tls_cert_key_custom(mock_configobj):
@@ -473,7 +473,7 @@ def test_tls_connect_invalid(mock_configobj):
     ]
     with pytest.raises(ValueError) as err:
         protobix.ZabbixAgentConfig('TLSConnect_invalid')
-    assert str(err.value) == 'TLSConnect must be one of [unencrypted,cert] (psk is not implemented)'
+    assert str(err.value) == 'TLSConnect must be one of [unencrypted,psk,cert]'
 
 @mock.patch('configobj.ConfigObj')
 def test_tls_connect_psk(mock_configobj):
@@ -486,6 +486,23 @@ def test_tls_connect_psk(mock_configobj):
             'TLSConnect': 'psk'
         }
     ]
-    with pytest.raises(NotImplementedError) as err:
+    with pytest.raises(ValueError) as err:
         protobix.ZabbixAgentConfig('TLSConnect_psk')
-    assert str(err.value) == 'TLSConnect must be one of [unencrypted,cert] (psk is not implemented)'
+    assert str(err.value) == 'TLSConnect is psk. TLSPSKIdentity and TLSPSKFile are mandatory'
+
+@mock.patch('configobj.ConfigObj')
+def test_tls_connect_psk(mock_configobj):
+    """
+    TLSConnect: 'psk'
+    Should raise a NotImplementedError with appropriate message
+    """
+    mock_configobj.side_effect = [
+        {
+            'TLSConnect': 'psk',
+            'TLSPSKIdentity': 'TLS PSK Zabbix Identity',
+            'TLSPSKFile': '/tmp/psk.file',
+        }
+    ]
+    zbx_config = protobix.ZabbixAgentConfig('TLSConnect_psk')
+    assert zbx_config.tls_psk_identity == 'TLS PSK Zabbix Identity'
+    assert zbx_config.tls_psk_file == '/tmp/psk.file'

--- a/tests/test_zabbixagentconfig.py
+++ b/tests/test_zabbixagentconfig.py
@@ -476,7 +476,7 @@ def test_tls_connect_invalid(mock_configobj):
     assert str(err.value) == 'TLSConnect must be one of [unencrypted,psk,cert]'
 
 @mock.patch('configobj.ConfigObj')
-def test_tls_connect_psk(mock_configobj):
+def test_tls_connect_psk_tls_msk_identity_file_missing(mock_configobj):
     """
     TLSConnect: 'psk'
     Should raise a NotImplementedError with appropriate message


### PR DESCRIPTION
* Add support for TLS PSK configuration options in ZabbixAgentConfig
* Make all options name coherent with Zabbix Agent ones. Arguments for SampleProbe are zabbix_sender ones
* Update ZabbixagentConfig test suite to get back 100% coverage after adding TLS PSK options