### PR TITLE
fixed 'data_type' in 'items' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ DATA = {
 }
 
 zbx_datacontainer = protobix.DataContainer()
-zbx_datacontainer.data_type = 'lld'
+zbx_datacontainer.data_type = 'items'
 zbx_datacontainer.add(DATA)
 zbx_datacontainer.send()
 ```


### PR DESCRIPTION
It was set to LLD. I vaguely remember seeing this before... :)