### PR TITLE
Fix failed test when running test suite as root

### DIFF
--- a/tests/test_sampleprobe.py
+++ b/tests/test_sampleprobe.py
@@ -335,6 +335,7 @@ Check logger configuration in file mode with invalid file
 Here, invalid means that it doesn't exists, or we don't have
 permission to write into
 """
+@pytest.mark.skipif(os.getuid() == 0, reason="requires non-root user")
 def test_log_file_invalid():
     pbx_test_probe = ProtobixTestProbe()
     pbx_test_probe._init_logging()


### PR DESCRIPTION
On unit test check failure when providing a log file where user has no write privileges.
Running the test suite as root makes the test to fail.
This PR aims to detect when running test suite as root and skip relevant tests