### PR TITLE
prefer newer unittest.mock when available

### DIFF
--- a/tests/test_datacontainer.py
+++ b/tests/test_datacontainer.py
@@ -3,12 +3,15 @@ Tests for protobix.SenderProtocol
 """
 import configobj
 import pytest
-import mock
 import unittest
 import time
 try: import simplejson as json
 except ImportError: import json
 import socket
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import sys
 import os

--- a/tests/test_memory_leak.py
+++ b/tests/test_memory_leak.py
@@ -3,8 +3,11 @@ Test long running process & detect memory leak
 """
 import configobj
 import pytest
-import mock
 import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import resource
 import sys

--- a/tests/test_sampleprobe.py
+++ b/tests/test_sampleprobe.py
@@ -3,9 +3,12 @@ Test Protobix sampleprobe
 """
 import configobj
 import pytest
-import mock
 import unittest
 import socket
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import resource
 import time

--- a/tests/test_senderprotocol.py
+++ b/tests/test_senderprotocol.py
@@ -3,12 +3,15 @@ Tests for protobix.SenderProtocol
 """
 import configobj
 import pytest
-import mock
 import unittest
 import time
 try: import simplejson as json
 except ImportError: import json
 import socket
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import sys
 import os

--- a/tests/test_zabbixagentconfig.py
+++ b/tests/test_zabbixagentconfig.py
@@ -3,9 +3,12 @@ Tests for protobix.ZabbixAgentConfig
 """
 import configobj
 import pytest
-import mock
 import unittest
 import logging
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import sys
 import os


### PR DESCRIPTION
mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.

https://github.com/testing-cabal/mock